### PR TITLE
fix: add sync before mounting the new image

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The output image file will be named as "resize.img"
 	* UC-8100-ME series:
 
 		including UC-8112-ME-T-LX, UC-8112-ME-T-LX1, UC-8112-ME-T-LX-US-LTE, UC-8112-ME-T-US-LTE-LX1
+	* UC-8410A series:
+
+		including UC-8410A-LX, UC-8410A-NW-LX, UC-8410A-T-LX, UC-8410A-NW-T-LX
+
 * Type B
 	* UC-2100 series:
 

--- a/resize-img
+++ b/resize-img
@@ -96,6 +96,8 @@ resize_image() {
 		./create-img "${RES_IMAGE_NAME}" "1,${p1_size},y,b,vfat" "2,${p2_size},n,83,ext4" "3,${p3_size},n,83,ext4"
 	fi
 
+	sync
+
 	log_msg "Mounting new image"
 	./mount-img mount "${RES_IMAGE_NAME}" "${RES_MNT_DIR}"
 


### PR DESCRIPTION
In MUS, we tested in virtual box with this script. If we didn't sync all the files, we can't mount the image just created.