### PR TITLE
Bugfix for Issue #6

### DIFF
--- a/create-img
+++ b/create-img
@@ -14,7 +14,7 @@
 
 set -e
 
-VERSION=1.3.0
+VERSION=1.3.1
 
 usage() {
 	echo -e "Usage:"
@@ -229,12 +229,17 @@ format_partitions() {
 		loopdev="$(losetup -f)"
 		losetup -o ${p_offset} --sizelimit ${p_size} ${loopdev} ${img}
 
+		# Get block size GH issue #6
+		# https://github.com/Moxa-Linux/resize-image/issues/6
+		o_loop=$(lsblk | grep original_mnt/p${i} | awk '{print $1}')
+		blocksize=$(dumpe2fs /dev/$o_loop 2>&1 | grep 'Block size' | awk '{print $3}')
+
 		# Perform formation for different fs_type
 		#   vfat: format
 		#   ext4: format with journal
 		#   raw: do nothing
 		if [ "${fs_type}" == "ext4" ]; then
-			mkfs -t ${fs_type} -J size=8 ${loopdev} >/dev/null 2>&1
+			mkfs -t ${fs_type} -b ${blocksize} -J size=8 ${loopdev} >/dev/null 2>&1
 		elif [ "${fs_type}" == "vfat" ]; then
 			mkfs -t ${fs_type} ${loopdev} >/dev/null
 		fi


### PR DESCRIPTION
This PR fixes #6 I pulled images from, and used all flags A, B, and C. Then I resized them and mounted the images with no issues. No more errors, output is clean now:

- 8200
- 8100
- 8100A

![8200](https://github.com/Moxa-Linux/resize-image/assets/10265682/6abe71a1-cce6-4513-b478-3aa9207a0abf)

![8100](https://github.com/Moxa-Linux/resize-image/assets/10265682/1198f94f-9d1f-4505-af0f-1d7c530fbba0)

![8100A](https://github.com/Moxa-Linux/resize-image/assets/10265682/4cdc8597-62f0-4ec7-bca3-dc2f88b3ebd9)
